### PR TITLE
Building options

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -32,6 +32,7 @@ var buildFlags = struct {
 	LeaveWorkspace bool
 	Workspace      string
 	BuildTags      []string
+	Vendor         bool
 }{}
 
 // buildCmd represents the build command
@@ -57,6 +58,7 @@ var buildCmd = &cobra.Command{
 			LeaveWorkspace: buildFlags.LeaveWorkspace,
 			TempFolder:     buildFlags.Workspace,
 			Tags:           buildFlags.BuildTags,
+			Vendor:         buildFlags.Vendor,
 		}
 		defer builder.Close()
 
@@ -117,4 +119,5 @@ func init() {
 	buildCmd.Flags().BoolVarP(&buildFlags.LeaveWorkspace, "leave-workspace", "l", false, "leave temporary build work space after execution")
 	buildCmd.Flags().StringVarP(&buildFlags.Workspace, "workspace", "w", "", "path where to create the build files, leave empty for temp folder")
 	buildCmd.Flags().StringSliceVar(&buildFlags.BuildTags, "tags", nil, "list of additional build tags to consider satisfied during the build")
+	buildCmd.Flags().BoolVarP(&buildFlags.Vendor, "vendor", "", false, "uses vendoring to keep all dependencies local")
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -30,6 +30,7 @@ var buildFlags = struct {
 	Output         string
 	Debug          bool
 	LeaveWorkspace bool
+	Workspace      string
 	BuildTags      []string
 }{}
 
@@ -54,6 +55,7 @@ var buildCmd = &cobra.Command{
 			Debug:          buildFlags.Debug,
 			Log:            log,
 			LeaveWorkspace: buildFlags.LeaveWorkspace,
+			TempFolder:     buildFlags.Workspace,
 			Tags:           buildFlags.BuildTags,
 		}
 
@@ -107,5 +109,6 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildFlags.Output, "output", "o", "./revad", "output file")
 	buildCmd.Flags().BoolVarP(&buildFlags.Debug, "debug", "d", false, "compile with debug symbols")
 	buildCmd.Flags().BoolVarP(&buildFlags.LeaveWorkspace, "leave-workspace", "l", false, "leave temporary build work space after execution")
+	buildCmd.Flags().StringVarP(&buildFlags.Workspace, "workspace", "w", "", "path where to create the build files, leave empty for temp folder")
 	buildCmd.Flags().StringSliceVar(&buildFlags.BuildTags, "tags", nil, "list of additional build tags to consider satisfied during the build")
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -58,8 +58,14 @@ var buildCmd = &cobra.Command{
 			TempFolder:     buildFlags.Workspace,
 			Tags:           buildFlags.BuildTags,
 		}
+		defer builder.Close()
 
-		err := builder.Build(ctx, buildFlags.Output)
+		err := builder.Prepare(ctx)
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		err = builder.Build(ctx, buildFlags.Output)
 		if err != nil {
 			log.Fatal().Err(err).Send()
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/cs3org/gaia/pkg/builder"
@@ -33,6 +35,8 @@ var buildFlags = struct {
 	Workspace      string
 	BuildTags      []string
 	Vendor         bool
+	OnlyPrepare    bool
+	OnlyBuild      bool
 }{}
 
 // buildCmd represents the build command
@@ -42,6 +46,20 @@ var buildCmd = &cobra.Command{
 	PreRunE: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
+
+		if buildFlags.OnlyPrepare && buildFlags.OnlyBuild {
+			fmt.Fprintln(os.Stderr, "Error: --only-prepare and --only-build cannot be used together")
+			os.Exit(1)
+		}
+
+		if buildFlags.OnlyPrepare {
+			buildFlags.LeaveWorkspace = true
+		}
+
+		if buildFlags.OnlyBuild && buildFlags.Workspace == "" {
+			fmt.Fprintln(os.Stderr, "Error: asking to only build without specifying an existing workspace")
+			os.Exit(2)
+		}
 
 		version := "latest"
 		if len(args) != 0 {
@@ -62,14 +80,18 @@ var buildCmd = &cobra.Command{
 		}
 		defer builder.Close()
 
-		err := builder.Prepare(ctx)
-		if err != nil {
-			log.Fatal().Err(err).Send()
+		if !buildFlags.OnlyBuild {
+			err := builder.Prepare(ctx)
+			if err != nil {
+				log.Fatal().Err(err).Send()
+			}
 		}
 
-		err = builder.Build(ctx, buildFlags.Output)
-		if err != nil {
-			log.Fatal().Err(err).Send()
+		if !buildFlags.OnlyPrepare {
+			err := builder.Build(ctx, buildFlags.Output)
+			if err != nil {
+				log.Fatal().Err(err).Send()
+			}
 		}
 	},
 }
@@ -120,4 +142,6 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildFlags.Workspace, "workspace", "w", "", "path where to create the build files, leave empty for temp folder")
 	buildCmd.Flags().StringSliceVar(&buildFlags.BuildTags, "tags", nil, "list of additional build tags to consider satisfied during the build")
 	buildCmd.Flags().BoolVarP(&buildFlags.Vendor, "vendor", "", false, "uses vendoring to keep all dependencies local")
+	buildCmd.Flags().BoolVarP(&buildFlags.OnlyPrepare, "only-prepare", "", false, "only run the prepare workspace stage (forces --leave-workspace)")
+	buildCmd.Flags().BoolVarP(&buildFlags.OnlyBuild, "only-build", "", false, "only run the build workspace stage (requires --workspace to be set)")
 }

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -46,6 +46,7 @@ type Builder struct {
 	Debug          bool
 	Log            *zerolog.Logger
 	LeaveWorkspace bool
+	Vendor         bool
 	w              *workspace
 }
 
@@ -143,6 +144,13 @@ func (b *Builder) Prepare(ctx context.Context) error {
 		return err
 	}
 
+	if b.Vendor {
+		// Keep all modules locally
+		if err := b.w.runGoCommand(ctx, "mod", "vendor"); err != nil {
+			return err
+		}
+	}
+
 	// add compile time flags for version, commit, go version and build date
 	// store them in the project so that it can be used independently
 	bflags := b.w.generateBuildFlags(b.Replacement)
@@ -204,6 +212,10 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 
 	b.Log.Debug().Interface("flags", bflags).Msg("using the following build flags")
 	args.Add("-ldflags", string(bflags))
+
+	if b.Vendor {
+		args.Add("-mod=vendor")
+	}
 
 	b.Log.Info().Msg("building revad binary")
 	if err := b.w.runGoBuildCommand(ctx, "main.go", output, args.Format()...); err != nil {

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -19,17 +19,11 @@
 package builder
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
-	"text/template"
 
 	"github.com/cs3org/gaia/internal/utils"
 	"github.com/rs/zerolog"
@@ -52,61 +46,16 @@ type Builder struct {
 	Debug          bool
 	Log            *zerolog.Logger
 	LeaveWorkspace bool
+	w              *workspace
 }
 
-type Plugin struct {
-	RepositoryPath string
-	Version        string
-}
-
-func (p Plugin) String() string {
-	s := p.RepositoryPath
-	if p.Version != "" {
-		s += "@" + p.Version
-	}
-	return s
-}
-
-type Replace struct {
-	From      string
-	To        string
-	ToVersion string
-}
-
-// Format formats the replacement string to be valid
-// with the go mod edit command.
-func (r Replace) Format() string {
-	s := r.From + "=" + r.To
-	if r.ToVersion != "" {
-		s += "@" + r.ToVersion
-	}
-	return s
-}
-
-func (r Replace) String() string {
-	s := r.From + " => " + r.To
-	if r.ToVersion != "" {
-		s += "@" + r.ToVersion
-	}
-	return s
-}
-
-func (b *Builder) Build(ctx context.Context, output string) error {
-	if output == "" {
-		return errors.New("output file name cannot be empty")
-	}
+func (b *Builder) getWorkspace() error {
 	if b.Log == nil {
 		log := zerolog.Nop()
 		b.Log = &log
 	}
 
-	b.Log.Info().Msgf("building reva using version %s", b.RevaVersion)
-
 	var err error
-	output, err = filepath.Abs(output)
-	if err != nil {
-		return err
-	}
 
 	if b.Platform.Arch == "" {
 		b.Platform.Arch = utils.KeyFromGoEnv("GOARCH")
@@ -118,19 +67,31 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 		b.RevaVersion = "latest"
 	}
 
-	w, err := b.newWorkspace()
+	b.w, err = b.newWorkspace()
 	if err != nil {
 		return err
 	}
-	defer w.Close()
 
-	w.setEnvKV("GOOS", b.Platform.OS)
-	w.setEnvKV("GOARCH", b.Platform.Arch)
+	b.w.setEnvKV("GOOS", b.Platform.OS)
+	b.w.setEnvKV("GOARCH", b.Platform.Arch)
 
-	if err := w.runGoCommand(ctx, "mod", "init", "revad"); err != nil {
+	return nil
+}
+
+func (b *Builder) Prepare(ctx context.Context) error {
+
+	if b.w == nil {
+		if err := b.getWorkspace(); err != nil {
+			return err
+		}
+	}
+
+	b.Log.Info().Msgf("preparing reva using version %s", b.RevaVersion)
+
+	if err := b.w.runGoCommand(ctx, "mod", "init", "revad"); err != nil {
 		return err
 	}
-	f, err := w.CreateFile("main.go")
+	f, err := b.w.CreateFile("main.go")
 	if err != nil {
 		return err
 	}
@@ -161,7 +122,7 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 
 	// do the replacement of the modules
 	if len(b.Replacement) != 0 {
-		if err := w.runGoModReplaceCommand(ctx, b.Replacement); err != nil {
+		if err := b.w.runGoModReplaceCommand(ctx, b.Replacement); err != nil {
 			return err
 		}
 	}
@@ -169,16 +130,52 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 	// TODO: verify all the versions
 	for _, plugin := range b.Plugins {
 		b.Log.Info().Msgf("adding plugin %s", plugin)
-		if err := w.runGoGetCommand(ctx, plugin.RepositoryPath, plugin.Version); err != nil {
+		if err := b.w.runGoGetCommand(ctx, plugin.RepositoryPath, plugin.Version); err != nil {
 			return err
 		}
 	}
-	if err := w.runGoGetCommand(ctx, revaRepository, b.RevaVersion); err != nil {
+	if err := b.w.runGoGetCommand(ctx, revaRepository, b.RevaVersion); err != nil {
 		return err
 	}
 
 	// run go mod tidy to fix all the modules
-	if err := w.runGoCommand(ctx, "mod", "tidy"); err != nil {
+	if err := b.w.runGoCommand(ctx, "mod", "tidy"); err != nil {
+		return err
+	}
+
+	// add compile time flags for version, commit, go version and build date
+	// store them in the project so that it can be used independently
+	bflags := b.w.generateBuildFlags(b.Replacement)
+	f, err = b.w.CreateFile("bflags")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(bflags.Format())
+	if err != nil {
+		panic(err)
+	}
+
+	return nil
+}
+
+func (b *Builder) Build(ctx context.Context, output string) error {
+
+	if b.w == nil {
+		if err := b.getWorkspace(); err != nil {
+			return err
+		}
+	}
+
+	b.Log.Info().Msgf("building reva using workspace %s", b.w.folder)
+
+	if output == "" {
+		return errors.New("output file name cannot be empty")
+	}
+	var err error
+	output, err = filepath.Abs(output)
+	if err != nil {
 		return err
 	}
 
@@ -194,89 +191,27 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 	}
 
 	// add compile time flags for version, commit, go version and build date
-	bflags := w.generateBuildFlags(b.Replacement)
-	b.Log.Debug().Interface("flags", bflags).Msg("using the following build flags")
-	args.Add("-ldflags", bflags.Format())
-
-	b.Log.Info().Msg("building revad binary")
-	if err := w.runGoBuildCommand(ctx, "main.go", output, args.Format()...); err != nil {
+	f, err := b.w.OpenFile("bflags")
+	if err != nil {
 		return err
 	}
+	defer f.Close()
 
+	bflags, err := os.ReadFile(f.Name())
+	if err != nil {
+		panic(err)
+	}
+
+	b.Log.Debug().Interface("flags", bflags).Msg("using the following build flags")
+	args.Add("-ldflags", string(bflags))
+
+	b.Log.Info().Msg("building revad binary")
+	if err := b.w.runGoBuildCommand(ctx, "main.go", output, args.Format()...); err != nil {
+		return err
+	}
 	return nil
 }
 
-func writeMainWithPlugins(f *os.File, plugins []Plugin) error {
-	plugins = slices.DeleteFunc(plugins, func(p Plugin) bool { return p.RepositoryPath == revaRepository })
-	return mainTemplate.Execute(f, struct {
-		Plugins  []Plugin
-		RevaRepo string
-	}{
-		Plugins:  plugins,
-		RevaRepo: revaRepository,
-	})
+func (b *Builder) Close() {
+	b.w.Close()
 }
-
-type GoMod struct {
-	Module struct {
-		Path string `json:"Path"`
-	} `json:"Module"`
-	Go      string `json:"Go"`
-	Require []struct {
-		Path     string `json:"Path"`
-		Version  string `json:"Version"`
-		Indirect bool   `json:"Indirect,omitempty"`
-	} `json:"Require"`
-	Exclude any `json:"Exclude"`
-	Replace []struct {
-		Old struct {
-			Path string `json:"Path"`
-		} `json:"Old"`
-		New struct {
-			Path    string `json:"Path"`
-			Version string `json:"Version"`
-		} `json:"New"`
-	} `json:"Replace"`
-	Retract any `json:"Retract"`
-}
-
-func parseGoModFile(ctx context.Context, path string) (*GoMod, error) {
-	var stdout bytes.Buffer
-
-	c := exec.CommandContext(ctx, utils.Go(), "mod", "edit", "-json", path)
-	c.Stdout = &stdout
-
-	if err := c.Run(); err != nil {
-		return nil, fmt.Errorf("error running command: %w", err)
-	}
-
-	var gomod GoMod
-	if err := json.NewDecoder(&stdout).Decode(&gomod); err != nil {
-		return nil, fmt.Errorf("error decoding go.mod: %w", err)
-	}
-	return &gomod, nil
-}
-
-func isRevaLocalReplacement(repl []Replace) (string, bool) {
-	for _, r := range repl {
-		if r.From == revaRepository {
-			_, err := os.Stat(r.To)
-			return r.To, err == nil
-		}
-	}
-	return "", false
-}
-
-var mainTemplate = template.Must(template.New("main.go").Parse(`package main
-
-import (
-	revadcmd "{{.RevaRepo}}/cmd/revad"
-{{- range .Plugins }}
-	_ "{{ .RepositoryPath }}"
-{{- end }}
-)
-
-func main() {
-	revadcmd.Main()
-}
-`))

--- a/pkg/builder/flags.go
+++ b/pkg/builder/flags.go
@@ -130,7 +130,7 @@ func getRevaVersion(w *workspace, replacements []Replace) string {
 	return m.Version
 }
 
-type GithubTagRef struct {
+type GithubRef struct {
 	Ref    string `json:"ref"`
 	NodeID string `json:"node_id"`
 	URL    string `json:"url"`
@@ -163,15 +163,32 @@ func getGitCommit(version string, replacements []Replace) string {
 		panic(err)
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		panic("status code is not 200")
+	if res.StatusCode == http.StatusOK {
+		var tag GithubRef
+		if err := json.NewDecoder(res.Body).Decode(&tag); err != nil {
+			panic(err)
+		}
+		return tag.Object.Sha[:9]
 	}
 
-	var tag GithubTagRef
-	if err := json.NewDecoder(res.Body).Decode(&tag); err != nil {
+	// Maybe we got a branch...
+	url = "https://api.github.com/repos/cs3org/reva/git/refs/heads/" + version
+	res, err = http.Get(url)
+	if err != nil {
 		panic(err)
 	}
-	return tag.Object.Sha[:9]
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusOK {
+		var tag GithubRef
+		if err := json.NewDecoder(res.Body).Decode(&tag); err != nil {
+			panic(err)
+		}
+		return tag.Object.Sha[:9]
+	}
+
+	// Maybe we got the sha already...
+	// Not worth checking
+	return version
 }
 
 func getBuildDate() time.Time {

--- a/pkg/builder/templater.go
+++ b/pkg/builder/templater.go
@@ -1,0 +1,126 @@
+package builder
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"text/template"
+
+	"github.com/cs3org/gaia/internal/utils"
+)
+
+type Plugin struct {
+	RepositoryPath string
+	Version        string
+}
+
+func (p Plugin) String() string {
+	s := p.RepositoryPath
+	if p.Version != "" {
+		s += "@" + p.Version
+	}
+	return s
+}
+
+type Replace struct {
+	From      string
+	To        string
+	ToVersion string
+}
+
+// Format formats the replacement string to be valid
+// with the go mod edit command.
+func (r Replace) Format() string {
+	s := r.From + "=" + r.To
+	if r.ToVersion != "" {
+		s += "@" + r.ToVersion
+	}
+	return s
+}
+
+func (r Replace) String() string {
+	s := r.From + " => " + r.To
+	if r.ToVersion != "" {
+		s += "@" + r.ToVersion
+	}
+	return s
+}
+
+func writeMainWithPlugins(f *os.File, plugins []Plugin) error {
+	plugins = slices.DeleteFunc(plugins, func(p Plugin) bool { return p.RepositoryPath == revaRepository })
+	return mainTemplate.Execute(f, struct {
+		Plugins  []Plugin
+		RevaRepo string
+	}{
+		Plugins:  plugins,
+		RevaRepo: revaRepository,
+	})
+}
+
+type GoMod struct {
+	Module struct {
+		Path string `json:"Path"`
+	} `json:"Module"`
+	Go      string `json:"Go"`
+	Require []struct {
+		Path     string `json:"Path"`
+		Version  string `json:"Version"`
+		Indirect bool   `json:"Indirect,omitempty"`
+	} `json:"Require"`
+	Exclude any `json:"Exclude"`
+	Replace []struct {
+		Old struct {
+			Path string `json:"Path"`
+		} `json:"Old"`
+		New struct {
+			Path    string `json:"Path"`
+			Version string `json:"Version"`
+		} `json:"New"`
+	} `json:"Replace"`
+	Retract any `json:"Retract"`
+}
+
+func parseGoModFile(ctx context.Context, path string) (*GoMod, error) {
+	var stdout bytes.Buffer
+
+	c := exec.CommandContext(ctx, utils.Go(), "mod", "edit", "-json", path)
+	c.Stdout = &stdout
+
+	if err := c.Run(); err != nil {
+		return nil, fmt.Errorf("error running command: %w", err)
+	}
+
+	var gomod GoMod
+	if err := json.NewDecoder(&stdout).Decode(&gomod); err != nil {
+		return nil, fmt.Errorf("error decoding go.mod: %w", err)
+	}
+	return &gomod, nil
+}
+
+func isRevaLocalReplacement(repl []Replace) (string, bool) {
+	for _, r := range repl {
+		if r.From == revaRepository {
+			_, err := os.Stat(r.To)
+			return r.To, err == nil
+		}
+	}
+	return "", false
+}
+
+var mainTemplate = template.Must(template.New("main.go").Parse(`package main
+
+import (
+	revadcmd "{{.RevaRepo}}/cmd/revad"
+{{- range .Plugins }}
+	_ "{{ .RepositoryPath }}"
+{{- end }}
+)
+
+func main() {
+	revadcmd.Main()
+}
+`))

--- a/pkg/builder/workspace.go
+++ b/pkg/builder/workspace.go
@@ -131,7 +131,7 @@ func (w workspace) runGoModReplaceCommand(ctx context.Context, replacement []Rep
 
 func (w workspace) newGoCommand(ctx context.Context, stderr io.Writer, args ...string) *exec.Cmd {
 	c := w.newCommand(ctx, utils.Go(), stderr, args...)
-	for _, env := range utils.FromGoEnv("GOPATH", "GOMODCACHE", "GOCACHE", "CGO_ENABLED") {
+	for _, env := range utils.FromGoEnv("GOPATH", "GOMODCACHE", "GOCACHE", "CGO_ENABLED", "GOPROXY") {
 		w.setEnv(env)
 	}
 	c.Env = w.goenv

--- a/pkg/builder/workspace.go
+++ b/pkg/builder/workspace.go
@@ -159,6 +159,11 @@ func (w workspace) CreateFile(name string) (*os.File, error) {
 	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 }
 
+func (w workspace) OpenFile(name string) (*os.File, error) {
+	path := filepath.Join(w.folder, name)
+	return os.OpenFile(path, os.O_RDONLY, 0644)
+}
+
 func (w workspace) Close() error {
 	if w.leave {
 		return nil

--- a/service/download.go
+++ b/service/download.go
@@ -75,6 +75,7 @@ func (s *Builder) download(w http.ResponseWriter, r *http.Request) {
 		Plugins:     plugins,
 		TempFolder:  s.c.BuildFolder,
 	}
+	defer b.Close()
 
 	output, err := os.CreateTemp(s.c.BinaryTempFolder, "revad")
 	if err != nil {
@@ -87,6 +88,11 @@ func (s *Builder) download(w http.ResponseWriter, r *http.Request) {
 
 	buildCtx, cancel := context.WithTimeout(ctx, s.c.BuildTimeout)
 	defer cancel()
+	if err := b.Prepare(buildCtx); err != nil {
+		log.Error().Err(err).Msg("error preparing build")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	if err := b.Build(buildCtx, output.Name()); err != nil {
 		log.Error().Err(err).Msg("error building reva")
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
This PR adds some extra options to allow us to:
- specify the workspace location
- to split the prepare and build stages (so that we can re-build from a worspace later)
- use mod vendoring
- set GOPROXY env var

It also contains a fix to allow us to give branches, tags and sha's as the ids of the versions to be used.