### PR TITLE
add(feat): static build flag and ldflags cli

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -39,6 +39,7 @@ var buildFlags = struct {
 	OnlyBuild      bool
 	LdFlags        string
 	Static         bool
+	StaticMusl     bool
 }{}
 
 // buildCmd represents the build command
@@ -51,6 +52,11 @@ var buildCmd = &cobra.Command{
 
 		if buildFlags.OnlyPrepare && buildFlags.OnlyBuild {
 			fmt.Fprintln(os.Stderr, "Error: --only-prepare and --only-build cannot be used together")
+			os.Exit(1)
+		}
+
+		if buildFlags.Static && buildFlags.StaticMusl {
+			fmt.Fprintln(os.Stderr, "Error: --static and --static-musl cannot be used together")
 			os.Exit(1)
 		}
 
@@ -81,6 +87,7 @@ var buildCmd = &cobra.Command{
 			Vendor:         buildFlags.Vendor,
 			LdFlags:        buildFlags.LdFlags,
 			Static:         buildFlags.Static,
+			StaticMusl:     buildFlags.StaticMusl,
 		}
 		defer builder.Close()
 
@@ -150,4 +157,5 @@ func init() {
 	buildCmd.Flags().BoolVarP(&buildFlags.OnlyBuild, "only-build", "", false, "only run the build workspace stage (requires --workspace to be set)")
 	buildCmd.Flags().StringVar(&buildFlags.LdFlags, "ldflags", "", "custom ldflags to inject (e.g., \"-extldflags=-static\")")
 	buildCmd.Flags().BoolVar(&buildFlags.Static, "static", false, "build statically linked binary (adds -extldflags=-static to ldflags)")
+	buildCmd.Flags().BoolVar(&buildFlags.StaticMusl, "static-musl", false, "build fully static binary using musl libc (requires musl-gcc, adds sqlite_omit_load_extension tag)")
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -37,6 +37,8 @@ var buildFlags = struct {
 	Vendor         bool
 	OnlyPrepare    bool
 	OnlyBuild      bool
+	LdFlags        string
+	Static         bool
 }{}
 
 // buildCmd represents the build command
@@ -77,6 +79,8 @@ var buildCmd = &cobra.Command{
 			TempFolder:     buildFlags.Workspace,
 			Tags:           buildFlags.BuildTags,
 			Vendor:         buildFlags.Vendor,
+			LdFlags:        buildFlags.LdFlags,
+			Static:         buildFlags.Static,
 		}
 		defer builder.Close()
 
@@ -144,4 +148,6 @@ func init() {
 	buildCmd.Flags().BoolVarP(&buildFlags.Vendor, "vendor", "", false, "uses vendoring to keep all dependencies local")
 	buildCmd.Flags().BoolVarP(&buildFlags.OnlyPrepare, "only-prepare", "", false, "only run the prepare workspace stage (forces --leave-workspace)")
 	buildCmd.Flags().BoolVarP(&buildFlags.OnlyBuild, "only-build", "", false, "only run the build workspace stage (requires --workspace to be set)")
+	buildCmd.Flags().StringVar(&buildFlags.LdFlags, "ldflags", "", "custom ldflags to inject (e.g., \"-extldflags=-static\")")
+	buildCmd.Flags().BoolVar(&buildFlags.Static, "static", false, "build statically linked binary (adds -extldflags=-static to ldflags)")
 }

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -49,6 +50,7 @@ type Builder struct {
 	Vendor         bool
 	LdFlags        string
 	Static         bool
+	StaticMusl     bool
 	w              *workspace
 }
 
@@ -78,6 +80,20 @@ func (b *Builder) getWorkspace() error {
 	b.w.setEnvKV("GOOS", b.Platform.OS)
 	b.w.setEnvKV("GOARCH", b.Platform.Arch)
 
+	if b.StaticMusl {
+		if err := b.checkMuslGcc(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *Builder) checkMuslGcc() error {
+	cmd := exec.Command("sh", "-c", "command -v musl-gcc")
+	if err := cmd.Run(); err != nil {
+		return errors.New("musl-gcc not found. Install with: sudo apt install musl-tools (or equivalent for your distribution)")
+	}
 	return nil
 }
 
@@ -189,6 +205,11 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 		return err
 	}
 
+	if b.StaticMusl {
+		b.w.setEnvKV("CC", "musl-gcc")
+		b.Log.Info().Msg("using musl-gcc for static build")
+	}
+
 	args := make(buildArgs)
 	if b.Debug {
 		args.Add("-gcflags", "all=-N -l")
@@ -196,7 +217,25 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 		args.Add("-trimpath", "")
 		args.Add("-ldflags", "-w", "-s")
 	}
-	if len(b.Tags) > 0 {
+
+	if b.StaticMusl {
+		tags := make([]string, 0, len(b.Tags)+1)
+		tags = append(tags, b.Tags...)
+		hasSqliteTag := false
+		for _, tag := range tags {
+			if tag == "sqlite_omit_load_extension" {
+				hasSqliteTag = true
+				break
+			}
+		}
+		if !hasSqliteTag {
+			tags = append(tags, "sqlite_omit_load_extension")
+			b.Log.Info().Msg("adding sqlite_omit_load_extension build tag for musl static build")
+		}
+		if len(tags) > 0 {
+			args.Add("-tags", strings.Join(tags, ","))
+		}
+	} else if len(b.Tags) > 0 {
 		args.Add("-tags", strings.Join(b.Tags, ","))
 	}
 
@@ -224,8 +263,17 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 		b.Log.Info().Str("ldflags", b.LdFlags).Msg("adding custom ldflags")
 	}
 
-	// Check if -extldflags=-static is already present to avoid duplication
-	if b.Static {
+	if b.StaticMusl {
+		if !strings.Contains(ldflags, "-extldflags") {
+			if ldflags != "" {
+				ldflags += " "
+			}
+			ldflags += "-extldflags '-static'"
+			b.Log.Info().Msg("adding musl static linking flags (-extldflags '-static')")
+		} else {
+			b.Log.Info().Msg("extldflags already present in ldflags, skipping")
+		}
+	} else if b.Static {
 		if !strings.Contains(ldflags, "-extldflags=-static") {
 			if ldflags != "" {
 				ldflags += " "

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -47,6 +47,8 @@ type Builder struct {
 	Log            *zerolog.Logger
 	LeaveWorkspace bool
 	Vendor         bool
+	LdFlags        string
+	Static         bool
 	w              *workspace
 }
 
@@ -211,7 +213,31 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 	}
 
 	b.Log.Debug().Interface("flags", bflags).Msg("using the following build flags")
-	args.Add("-ldflags", string(bflags))
+
+	ldflags := string(bflags)
+
+	if b.LdFlags != "" {
+		if ldflags != "" {
+			ldflags += " "
+		}
+		ldflags += b.LdFlags
+		b.Log.Info().Str("ldflags", b.LdFlags).Msg("adding custom ldflags")
+	}
+
+	// Check if -extldflags=-static is already present to avoid duplication
+	if b.Static {
+		if !strings.Contains(ldflags, "-extldflags=-static") {
+			if ldflags != "" {
+				ldflags += " "
+			}
+			ldflags += "-extldflags=-static"
+			b.Log.Info().Msg("adding static linking flags (-extldflags=-static)")
+		} else {
+			b.Log.Info().Msg("static linking flag already present in ldflags, skipping")
+		}
+	}
+
+	args.Add("-ldflags", ldflags)
 
 	if b.Vendor {
 		args.Add("-mod=vendor")
@@ -221,6 +247,7 @@ func (b *Builder) Build(ctx context.Context, output string) error {
 	if err := b.w.runGoBuildCommand(ctx, "main.go", output, args.Format()...); err != nil {
 		return err
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
I need CGO_ENABLED=1 and also need the static build (to use with distro-less docker image)
```text
# Build with static linking (convenience flag)
gaia build --static --with github.com/cernbox/reva-plugins

# Build with custom ldflags
gaia build --ldflags "-extldflags=-static" --with github.com/cernbox/reva-plugins

# Both can be combined (static flag adds -extldflags=-static, custom ldflags appended)
gaia build --static --ldflags "-X main.version=1.0.0"
```